### PR TITLE
Do not parse geoJson geometry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(CSS_TARGET): $(CSS_MAIN)
 	$(NODE_BIN)/yuicompressor $< -o $@
 
 $(CSS_MAIN): $(CSS_MAIN_NO_PREFIX) | dist
-	$(NODE_BIN)/autoprefixer $< -o $@
+	$(NODE_BIN)/postcss --use autoprefixer -c postcss.json $< -o $@
 
 .PHONY: $(CSS_MAIN_NO_PREFIX)
 $(CSS_MAIN_NO_PREFIX): $(MAIN_LESS) | build
@@ -48,7 +48,6 @@ dist:
 	mkdir -p dist
 
 clean: clean_js
-	rm -rf node_modules
 
 clean_js:
 	rm -rf dist build

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/citycontext/citycontext-ui",
   "readme": "README.md",
   "devDependencies": {
-    "autoprefixer": "^5.1.0",
     "browserify": "^9.0.3",
     "install": "^0.1.8",
     "jshint": "^2.6.3",
@@ -34,8 +33,10 @@
     "yuicompressor": "^2.4.8"
   },
   "dependencies": {
+    "autoprefixer": "^5.2.0",
     "chart.js": "^1.0.2",
     "mapbox.js": "^2.1.6",
+    "postcss-cli": "^1.3.1",
     "promise": "^6.1.0",
     "react": "^0.13.1",
     "request": "^2.54.0"

--- a/postcss.json
+++ b/postcss.json
@@ -1,0 +1,5 @@
+{
+    "autoprefixer": {
+        "browsers": "> 5%"
+    }
+}

--- a/widgets/criminality/results.js
+++ b/widgets/criminality/results.js
@@ -16,7 +16,7 @@ var Results = R.createClass({
     if (!this.props.data) { return D.div(); }
     var style     = this.props.show ? {} : { display: 'none' };
     var data      = this.props.data;
-    var geoJSON   = JSON.parse(data.lsoa.geometry);
+    var geoJSON   = data.lsoa.geometry;
     var crimeData = data.lsoa.crimes;
     var lsoaName  = data.lsoa.name;
     var sectionEl;

--- a/widgets/criminality/results.js
+++ b/widgets/criminality/results.js
@@ -16,7 +16,8 @@ var Results = R.createClass({
     if (!this.props.data) { return D.div(); }
     var style     = this.props.show ? {} : { display: 'none' };
     var data      = this.props.data;
-    var geoJSON   = data.lsoa.geometry;
+    var geom      = data.lsoa.geometry;
+    var geoJSON   = (typeof geom === "string") ? JSON.parse(geom) : geom;
     var crimeData = data.lsoa.crimes;
     var lsoaName  = data.lsoa.name;
     var sectionEl;

--- a/widgets/demographics/results.js
+++ b/widgets/demographics/results.js
@@ -16,7 +16,7 @@ var Results = R.createClass({
     if (!this.props.data) { return D.div(); }
     var style     = this.props.show ? {} : { display: 'none' };
     var data      = this.props.data;
-    var geoJSON   = JSON.parse(data.lsoa.geometry);
+    var geoJSON   = data.lsoa.geometry;
     var popData   = data.lsoa.population;
     var lsoaName  = data.lsoa.name;
     var sectionEl;

--- a/widgets/demographics/results.js
+++ b/widgets/demographics/results.js
@@ -16,7 +16,8 @@ var Results = R.createClass({
     if (!this.props.data) { return D.div(); }
     var style     = this.props.show ? {} : { display: 'none' };
     var data      = this.props.data;
-    var geoJSON   = data.lsoa.geometry;
+    var geom      = data.lsoa.geometry;
+    var geoJSON   = (typeof geom === "string") ? JSON.parse(geom) : geom;
     var popData   = data.lsoa.population;
     var lsoaName  = data.lsoa.name;
     var sectionEl;


### PR DESCRIPTION
The upcoming release of City Context API renders the `lsoa` -> `geometry` field as a proper JSON object instead of a string. This change prevents a client-side regression which would result in the criminality and demographics widgets not displaying.

Also update Makefile to use `postcss` version of autoprefixer (as per deprecation warning).  
